### PR TITLE
feat: OAuth2UserProfile dto (#2)

### DIFF
--- a/backend/dekku/src/main/java/com/a306/dekku/domain/auth/model/dto/KakaoUserProfile.java
+++ b/backend/dekku/src/main/java/com/a306/dekku/domain/auth/model/dto/KakaoUserProfile.java
@@ -1,0 +1,18 @@
+package com.a306.dekku.domain.auth.model.dto;
+
+import java.util.Map;
+
+public class KakaoUserProfile implements OAuth2UserProfile {
+
+    private final String id;
+
+    public KakaoUserProfile(Map<String, Object> attributes) {
+        this.id = String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getProviderId() {
+        return id;
+    }
+
+}

--- a/backend/dekku/src/main/java/com/a306/dekku/domain/auth/model/dto/OAuth2UserProfile.java
+++ b/backend/dekku/src/main/java/com/a306/dekku/domain/auth/model/dto/OAuth2UserProfile.java
@@ -1,0 +1,5 @@
+package com.a306.dekku.domain.auth.model.dto;
+
+public interface OAuth2UserProfile {
+    String getProviderId();
+}


### PR DESCRIPTION
# KakaoUserProfile

## 📌 역할
➡ Kakao OAuth2 로그인 후 사용자 정보를 담은 DTO

### 1️⃣ Kakao 로 부터 받은 사용자 id 관리

### 2️⃣ id 반환

## 📌 역할별 코드

### 1️⃣ Kakao로 부터 받은 사용자 JSON 데이터의 id 속성 추출
``` java
private final String id;

public KakaoUserProfile(Map<String, Object> attributes) {
    this.id = String.valueOf(attributes.get("id"));
}
```

### 2️⃣ id 필드를 관리
``` java
@Override
public String getProviderId() {
    return id;
}
```

## 📌 DTO 별도 관리 이유

- 구글 로그인은 id가 아니라 sub 속성에 담겨 옴

- OAuth2 제공자별로 JSON 데이터 구조가 다르므로, DTO 클래스를 각각 생성하는 것이 유지보수에 용이

- DTO는 데이터 저장만 담당하고, 비즈니스 로직은 OAuth2UserDetails에서 처리