### PR TITLE
feat: CustomOAuth2UserService (#2)

### DIFF
--- a/backend/dekku/src/main/java/com/a306/dekku/domain/auth/service/CustomOAuth2UserService.java
+++ b/backend/dekku/src/main/java/com/a306/dekku/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,73 @@
+package com.a306.dekku.domain.auth.service;
+
+import com.a306.dekku.domain.auth.security.CustomOAuth2User;
+import com.a306.dekku.domain.auth.security.OAuth2UserDetails;
+import com.a306.dekku.domain.member.model.entity.Member;
+import com.a306.dekku.domain.member.model.entity.enums.ProviderType;
+import com.a306.dekku.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * @param userRequest OAuth2 로그인 요청 객체 (OAuth2 제공자 정보 포함)
+     * @return Spring Security에서 사용할 CustomOAuth2User 객체
+     * @throws OAuth2AuthenticationException OAuth2 인증 과정에서 오류가 발생할 경우 예외 발생
+     */
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("getAttributes : {}", oAuth2User.getAttributes());
+
+        ProviderType providerType = ProviderType.convertToEnum(userRequest.getClientRegistration().getRegistrationId());
+
+        OAuth2UserDetails oAuth2UserDetails = OAuth2UserDetailsFactory.getOAuth2UserDetails(providerType, oAuth2User);
+        String providerId = oAuth2UserDetails.getProviderId();
+
+        Optional<Member> member = memberRepository.findByProviderId(providerId);
+
+        return CustomOAuth2User.of(
+                member.orElseGet(() ->
+                        memberRepository.save(
+                                Member.builder()
+                                        .provider(providerType)
+                                        .providerId(providerId)
+                                        .build()
+                        )),
+                oAuth2User.getAttributes()
+        );
+    }
+
+    /**
+     * @param providerId JWT 토큰에 담긴 providerId (OAuth2 제공자의 사용자 ID)
+     * @return 인증된 사용자 정보를 포함한 CustomOAuth2User 객체
+     * @throws UsernameNotFoundException providerId에 해당하는 회원 정보가 없을 경우 예외 발생
+     */
+    @Transactional
+    public CustomOAuth2User loadUserByProviderId(String providerId) {
+
+        Member member = memberRepository.getOrThrow(providerId);
+        return CustomOAuth2User.of(member, Collections.emptyMap());
+
+    }
+
+
+}


### PR DESCRIPTION
# CustomOAuth2UserService

## 📌 역할
➡ OAuth2 로그인 및 JWT 인증 시 사용자 정보를 조회하고 Spring Security에서 관리할 수 있도록 변환하는 서비스 클래스

### 1️⃣ OAuth2 로그인 시 사용자 정보를 조회하고 저장

### 2️⃣ JWT 인증 시 providerId 기반으로 사용자 조회
loadUserByProviderId(String providerId)

Spring Security의 CustomOAuth2User 객체로 변환하여 반환

## 📌 역할별 코드

### 1️⃣ OAuth2 제공자(Google, Kakao)로부터 사용자 정보를 가져와서 기존 사용자 여부 확인, 없으면 새 사용자로 등록
``` java
@Override
@Transactional
public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {

    OAuth2User oAuth2User = super.loadUser(userRequest);
    log.info("getAttributes : {}", oAuth2User.getAttributes());

    ProviderType providerType = ProviderType.convertToEnum(userRequest.getClientRegistration().getRegistrationId());

    OAuth2UserDetails oAuth2UserDetails = OAuth2UserDetailsFactory.getOAuth2UserDetails(providerType, oAuth2User);
    String providerId = oAuth2UserDetails.getProviderId();

    Optional<Member> member = memberRepository.findByProviderId(providerId);

    return CustomOAuth2User.of(
            member.orElseGet(() ->
                    memberRepository.save(
                            Member.builder()
                                    .provider(providerType)
                                    .providerId(providerId)
                                    .build()
                    )),
            oAuth2User.getAttributes()
    );
}
```

- OAuth2 제공자로부터 사용자 정보를 가져옴 (Google, Kakao 등)
``` java
OAuth2User oAuth2User = super.loadUser(userRequest);
log.info("getAttributes : {}", oAuth2User.getAttributes());
```

- ProviderType을 변환하여 OAuth2UserDetails 구현체(KakaoUserDetails 등)를 생성
``` java
ProviderType providerType = ProviderType.convertToEnum(userRequest.getClientRegistration().getRegistrationId());

OAuth2UserDetails oAuth2UserDetails = OAuth2UserDetailsFactory.getOAuth2UserDetails(providerType, oAuth2User);
String providerId = oAuth2UserDetails.getProviderId();
```

- providerId(OAuth2 제공자의 사용자 ID)를 기반으로 기존 회원을 조회
``` java
Optional<Member> member = memberRepository.findByProviderId(providerId);
```

- 기존 회원이 있다면 해당 회원 정보를 사용하고, 없으면 새 회원을 저장
``` java
member.orElseGet(() ->
          memberRepository.save(
                  Member.builder()
                          .provider(providerType)
                          .providerId(providerId)
                          .build()
          ))
```

- 최종적으로 CustomOAuth2User 객체를 반환하여 Spring Security의 인증 객체로 사용됨
``` java
return CustomOAuth2User.of(
            member.orElseGet(() ->
                    memberRepository.save(
                            Member.builder()
                                    .provider(providerType)
                                    .providerId(providerId)
                                    .build()
                    )),
            oAuth2User.getAttributes()
    );
```

### 2️⃣ JWT 토큰에서 providerId를 추출한 후, 해당하는 회원 정보를 조회

``` java
@Transactional
public CustomOAuth2User loadUserByProviderId(String providerId) {

    Member member = memberRepository.getOrThrow(providerId);
    return CustomOAuth2User.of(member, Collections.emptyMap());

}
```

- 클라이언트가 JWT를 통해 인증 요청을 하면, JWT 토큰에서 providerId(구글/카카오 계정 ID)를 추출

- providerId를 기반으로 데이터베이스에서 해당 회원(Member) 정보를 조회

- 회원 정보가 존재하면 CustomOAuth2User 객체로 변환하여 반환

- 회원 정보가 존재하지 않으면 예외 반환 (`getOrThrow(providerId)`)