### PR TITLE
global/constant/JwtKey

### DIFF
--- a/backend/dekku/src/main/java/com/a306/dekku/global/constant/JwtKey.java
+++ b/backend/dekku/src/main/java/com/a306/dekku/global/constant/JwtKey.java
@@ -1,10 +1,15 @@
 package com.a306.dekku.global.constant;
 
 public class JwtKey {
+
+    public static final String TOKEN_PREFIX = "Bearer ";  // JWT 인증 헤더의 토큰 접두어
+    public static final String ACCESS_TOKEN_KEY = "access_token";  // 액세스 토큰 키 이름
+    public static final String REFRESH_TOKEN_KEY = "refresh_token";  // 리프레쉬 토큰 키 이름
     /**
      * JWT - 리프레쉬 토큰을 Redis에 저장할 때 사용되는 키의 prefix.
      * %s 자리에 사용자의 providerId가 들어감.
      * 예시: "member:1234:refresh_token:" (1234는 providerId)
      */
     public static final String REFRESH_TOKEN_KEY_PREFIX = "member:%s:refresh_token:";
+
 }


### PR DESCRIPTION
# JwtKey

## 📌 역할
➡ Jwt와 관련된 상수를 저장하는 클래스

### 1️⃣ 리프레쉬 토큰이 저장될 레디스의 prefix 키 값을 상수형으로 저장

## 📌 기존 코드

➡ 기존에는 JWT 관련 키 값이 서비스 클래스 내에 직접 선언되어 있었음.  

예를 들어, `RedisTokenServiceImpl` 내부에서 Redis의 Refresh Token Key Prefix를 관리

``` java
public class RedisTokenServiceImpl implements RedisTokenService {

  private final RedisTemplate<String, Object> redisTemplate;
  private final String REFRESH_TOKEN_KEY_PREFIX = "member:%s:refresh_token:";
  private final JwtProperties jwtProperties;
  
  @Override
  public void save(String key, String value) {
      redisTemplate.opsForValue().set(
              String.format(REFRESH_TOKEN_KEY_PREFIX, key),
              value,
              jwtProperties.expiration().refresh(),
              TimeUnit.SECONDS
      );
  }

  /** 중략 **/

}
```

### ❗️ 문제점

서비스 클래스(RedisTokenServiceImpl)가 JWT 관련 키 값을 직접 관리하면 유지보수가 어려움

여러 서비스에서 동일한 키 값을 사용할 경우 중복 코드 발생


## 📌 개선된 코드
``` java
public class JwtKey {
    public static final String REFRESH_TOKEN_KEY_PREFIX = "member:%s:refresh_token:";
}
```

✅ 이를 통해 `RedisTokenServiceImpl` `REFRESH_TOKEN_KEY_PREFIX`를 가져다 사용하므로 유지보수 향상

✅ JWT 관련 키 값이 `JwtKey`에서 관리되므로, 코드의 일관성 증가